### PR TITLE
Added support for connections to local Azure storage emulators with HTTP connections

### DIFF
--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -35,24 +35,15 @@
     name: 'subfolder',
     value: volume.subfolder,
     label: "Subfolder",
-    instructions: 'If you want to use a container’s subfolder as a Volume, specify the path to use here.',
+    instructions: 'If you want to use a container\'s subfolder as a Volume, specify the path to use here.',
     suggestEnvVars: true,
 }) }}
 
 {{ forms.autosuggestField({
-    id: 'blobEndpointHostName',
-    name: 'blobEndpointHostName',
-    value: volume.blobEndpointHostName,
-    label: "Blob Endpoint Host Name",
-    instructions: 'The hostname of the Azure Storage Blob Endpoint to connect to. Use this if you have a non-standard Azure Storage Blob Endpoint or if you are connecting to a local Azure Storage Emulator. Leave blank to default to the standard Azure Storage Blob Endpoint.',
+    id: 'blobEndpoint',
+    name: 'blobEndpoint',
+    value: volume.blobEndpoint,
+    label: "Blob Endpoint URL",
+    instructions: 'The absolute URL of the Azure Storage Blob Endpoint to connect to. Use this if you have a non-standard Azure Storage Blob Endpoint or if you are connecting to a local Azure Storage Emulator. If supplied, the protocol of this URL will determine whether a connection is made using HTTP or HTTPS. Leave blank to default to the standard Azure Storage Blob Endpoint using HTTPS.',
     suggestEnvVars: true,
-}) }}
-
-{{ forms.lightswitchField({
-    id: 'httpsEnabled',
-    name: 'httpsEnabled',
-    label: "Enable HTTPS",
-    instructions: 'Enable or disable HTTPS connections to the Azure Storage account. Disable if you need to connect to a local Azure storage emulator that doesn\'t support HTTPS.',
-    on: volume.httpsEnabled,
-    first: true,
 }) }}

--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -38,3 +38,21 @@
     instructions: 'If you want to use a container’s subfolder as a Volume, specify the path to use here.',
     suggestEnvVars: true,
 }) }}
+
+{{ forms.autosuggestField({
+    id: 'blobEndpointHostName',
+    name: 'blobEndpointHostName',
+    value: volume.blobEndpointHostName,
+    label: "Blob Endpoint Host Name",
+    instructions: 'The hostname of the Azure Storage Blob Endpoint to connect to. Use this if you have a non-standard Azure Storage Blob Endpoint or if you are connecting to a local Azure Storage Emulator. Leave blank to default to the standard Azure Storage Blob Endpoint.',
+    suggestEnvVars: true,
+}) }}
+
+{{ forms.lightswitchField({
+    id: 'httpsEnabled',
+    name: 'httpsEnabled',
+    label: "Enable HTTPS",
+    instructions: 'Enable or disable HTTPS connections to the Azure Storage account. Disable if you need to connect to a local Azure storage emulator that doesn\'t support HTTPS.',
+    on: volume.httpsEnabled,
+    first: true,
+}) }}


### PR DESCRIPTION
Added support for connecting to Azure storage accounts with non-standard blob endpoint hostnames or HTTP connections (Handy for connecting to a local Azure storage emulator like Azurite).

I need this because I am using docker for my local Craft CMS development and need my craft cms container to be able to connect to my local Azurite container. Azurite is a local storage emulator for Azure Storage provided by Microsoft.

This is a fix for issue #5. Please review and merge in if all good. Otherwise, please let me know if there is anything you would like me to change. I have tested it on my local instance of Craft CMS version 3.5.8, but please feel free to do some additional testing. The new settings fields I have added in are optional and shouldn't affect existing installations.

Thank you! 🙂🙏